### PR TITLE
Ifpack2: fixed AdditiveSchwarz test failure

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
@@ -280,8 +280,8 @@ void Amesos2Wrapper<MatrixType>::initialize ()
   using Teuchos::rcp_dynamic_cast;
   using Teuchos::Time;
   using Teuchos::TimeMonitor;
-  typedef Tpetra::Import<local_ordinal_type,
-    global_ordinal_type, node_type> import_type;
+  using Teuchos::Array;
+  using Teuchos::ArrayView;
 
   const std::string timerName ("Ifpack2::Amesos2Wrapper::initialize");
   RCP<Time> timer = TimeMonitor::lookupCounter (timerName);
@@ -311,29 +311,33 @@ void Amesos2Wrapper<MatrixType>::initialize ()
     {
       // The matrix that Amesos2 will build the preconditioner on must be a Tpetra::Crs matrix.
       // If A_local isn't, then we build one.
-      RCP<const crs_matrix_type> A_local_crs =
-        rcp_dynamic_cast<const crs_matrix_type> (A_local);
+      A_local_crs_ = rcp_dynamic_cast<const crs_matrix_type> (A_local);
 
-      if (A_local_crs.is_null ()) {
-        // FIXME (mfh 24 Jan 2014) It would be smarter to count up the
-        // number of elements in each row of A_local, so that we can
-        // create A_local_crs_nc using static profile.  The code below is
-        // correct but potentially slow.
+      if (A_local_crs_.is_null ()) {
+        local_ordinal_type numRows = A_local->getNodeNumRows();
+        Array<size_t> entriesPerRow(numRows);
+        for(local_ordinal_type i = 0; i < numRows; i++)
+        {
+          entriesPerRow[i] = A_local->getNumEntriesInLocalRow(i);
+        }
         RCP<crs_matrix_type> A_local_crs_nc =
           rcp (new crs_matrix_type (A_local->getRowMap (),
-                                    A_local->getColMap (), 0));
-        // FIXME (mfh 24 Jan 2014) This Import approach will only work
-        // if A_ has a one-to-one row Map.  This is generally the case
-        // with matrices given to Ifpack2.
-        //
-        // Source and destination Maps are the same in this case.
-        // That way, the Import just implements a copy.
-        import_type import (A_local->getRowMap (), A_local->getRowMap ());
-        A_local_crs_nc->doImport (*A_local, import, Tpetra::REPLACE);
+                                    A_local->getColMap (),
+                                    entriesPerRow()));
+        // copy entries into A_local_crs
+        Teuchos::Array<local_ordinal_type> indices(A_local->getNodeMaxNumRowEntries());
+        Teuchos::Array<scalar_type> values(A_local->getNodeMaxNumRowEntries());
+        for(local_ordinal_type i = 0; i < numRows; i++)
+        {
+          size_t numEntries = 0;
+          A_local->getLocalRowCopy(i, indices(), values(), numEntries);
+          ArrayView<const local_ordinal_type> indicesInsert(indices.data(), numEntries);
+          ArrayView<const scalar_type> valuesInsert(values.data(), numEntries);
+          A_local_crs_nc->insertLocalValues(i, indicesInsert, valuesInsert);
+        }
         A_local_crs_nc->fillComplete (A_local->getDomainMap (), A_local->getRangeMap ());
-        A_local_crs = rcp_const_cast<const crs_matrix_type> (A_local_crs_nc);
+        A_local_crs_ = rcp_const_cast<const crs_matrix_type> (A_local_crs_nc);
       }
-      A_local_crs_ = A_local_crs;
     }
 
     // FIXME (10 Dec 2013, 25 Aug 2015) It shouldn't be necessary to


### PR DESCRIPTION
Fixed 3 unit tests under AdditiveSchwarz that failed with
deprecated code off. In RILUK and Amesos2Wrapper,
Tpetra::CrsMatrix::doImport() was being used to copy
a ReorderFilter to a CrsMatrix. The import's src/dst maps were the same.
But, that now requires the source matrix to support getGraph,
which ReorderFilter does not.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
